### PR TITLE
Tests: add more debugging, and a bugfix for dequeue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,36 @@
 CC=gcc
+CFLAGS=-std=gnu99 -O3 -Wall -Wextra -g
+LDFLAGS=-g
+LOADLIBS=-lpthread
 
+all : bin/test_p1c1 bin/test_p4c4 bin/test_p100c10 bin/test_p10c100 bin/example
 
-all : p1c1 p4c4 p100c10 p10c100 example
+bin/example: example.c liblfq.so.1.0.0
+	gcc $(CFLAGS) $(LDFLAGS) example.c lfq.c -o bin/example -lpthread
 
-example: liblfq
-	gcc -std=c99 -g example.c lfq.c -o bin/example -lpthread
+bin/test_p1c1: liblfq.so.1.0.0 test_multithread.c
+	gcc $(CFLAGS) $(LDFLAGS) test_multithread.c -o bin/test_p1c1 -L. -Wl,-Bstatic -llfq -Wl,-Bdynamic -lpthread -D MAX_PRODUCER=1 -D MAX_CONSUMER=1
 
-p1c1: liblfq
-	gcc -std=c99 -g test_multithread.c -o bin/test_p1c1 -L. -Wl,-Bstatic -llfq -Wl,-Bdynamic -lpthread -D MAX_PRODUCER=1 -D MAX_CONSUMER=1 
-	
-p4c4: liblfq
-	gcc -std=c99 -g test_multithread.c -o bin/test_p4c4 -L. -Wl,-Bstatic -llfq -Wl,-Bdynamic -lpthread -D MAX_PRODUCER=4 -D MAX_CONSUMER=4
+bin/test_p4c4: liblfq.so.1.0.0 test_multithread.c
+	gcc $(CFLAGS) $(LDFLAGS) test_multithread.c -o bin/test_p4c4 -L. -Wl,-Bstatic -llfq -Wl,-Bdynamic -lpthread -D MAX_PRODUCER=4 -D MAX_CONSUMER=4
 
-p100c10: liblfq
-	gcc -std=c99 -g test_multithread.c -o bin/test_p100c10 -L. -Wl,-Bstatic -llfq -Wl,-Bdynamic -lpthread -D MAX_PRODUCER=100 -D MAX_CONSUMER=10
-	
-p10c100: liblfq
-	gcc -std=c99 -g test_multithread.c -o bin/test_p10c100 -L. -Wl,-Bstatic -llfq -Wl,-Bdynamic -lpthread -D MAX_PRODUCER=10 -D MAX_CONSUMER=100
-	
-liblfq: lfq.c 
-	@gcc -std=c99 -c -O3 lfq.c -lpthread
-	@ar rcs liblfq.a lfq.o
-	@gcc -std=c99 -fPIC -c lfq.c
-	@gcc -shared -o liblfq.so.1.0.0 lfq.o
-	
-test:
-	@bin/test_p1c1
-	@bin/test_p4c4
-	@bin/test_p100c10
-	@bin/test_p10c100
-	
+bin/test_p100c10: liblfq.so.1.0.0 test_multithread.c
+	gcc $(CFLAGS) $(LDFLAGS) test_multithread.c -o bin/test_p100c10 -L. -Wl,-Bstatic -llfq -Wl,-Bdynamic -lpthread -D MAX_PRODUCER=100 -D MAX_CONSUMER=10
+
+bin/test_p10c100: liblfq.so.1.0.0 test_multithread.c
+	gcc $(CFLAGS) $(LDFLAGS) test_multithread.c -o bin/test_p10c100 -L. -Wl,-Bstatic -llfq -Wl,-Bdynamic -lpthread -D MAX_PRODUCER=10 -D MAX_CONSUMER=100
+
+liblfq.so.1.0.0: lfq.c lfq.h cross-platform.h
+	gcc $(CFLAGS) -c lfq.c   # -fno-pie for static linking?
+	ar rcs liblfq.a lfq.o
+	gcc $(CFLAGS) -fPIC -c lfq.c
+	gcc $(LDFLAGS) -shared -o liblfq.so.1.0.0 lfq.o
+
+test: bin/test_p1c1 bin/test_p4c4 bin/test_p100c10 bin/test_p10c100
+	bin/test_p1c1
+	bin/test_p4c4
+	bin/test_p100c10
+	bin/test_p10c100
+
 clean:
 	rm -rf *.o bin/* liblfq.so.1.0.0 liblfq.a

--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,16 @@ bin/test_p10c100: liblfq.so.1.0.0 test_multithread.c
 	gcc $(CFLAGS) $(LDFLAGS) test_multithread.c -o bin/test_p10c100 -L. -Wl,-Bstatic -llfq -Wl,-Bdynamic -lpthread -D MAX_PRODUCER=10 -D MAX_CONSUMER=100
 
 liblfq.so.1.0.0: lfq.c lfq.h cross-platform.h
-	gcc $(CFLAGS) -c lfq.c   # -fno-pie for static linking?
+	gcc $(CFLAGS) $(CPPFLAGS) -c lfq.c   # -fno-pie for static linking?
 	ar rcs liblfq.a lfq.o
-	gcc $(CFLAGS) -fPIC -c lfq.c
+	gcc $(CFLAGS) $(CPPFLAGS) -fPIC -c lfq.c
 	gcc $(LDFLAGS) -shared -o liblfq.so.1.0.0 lfq.o
 
 test: bin/test_p1c1 bin/test_p4c4 bin/test_p100c10 bin/test_p10c100
-	bin/test_p1c1
-	bin/test_p4c4
-	bin/test_p100c10
-	bin/test_p10c100
+	$(TESTWRAPPER) bin/test_p1c1
+	$(TESTWRAPPER) bin/test_p4c4
+	$(TESTWRAPPER) bin/test_p100c10
+	$(TESTWRAPPER) bin/test_p10c100
 
 clean:
 	rm -rf *.o bin/* liblfq.so.1.0.0 liblfq.a

--- a/cross-platform.h
+++ b/cross-platform.h
@@ -38,15 +38,20 @@
 #define ATOMIC_SET __sync_lock_test_and_set
 #define ATOMIC_RELEASE __sync_lock_release
 
-#if defined __GNUC__ || defined __CYGWIN__ || defined __MINGW32__
+#if defined __GNUC__
 	#define ATOMIC_SUB __sync_sub_and_fetch
 	#define ATOMIC_SUB64 ATOMIC_SUB
 	#define CAS __sync_bool_compare_and_swap
+#define XCHG __sync_lock_test_and_set   // yes really.  The 2nd arg is limited to 1 on machines with TAS but not XCHG.  On x86 it's an arbitrary value
 	#define ATOMIC_ADD __sync_add_and_fetch
 	#define ATOMIC_ADD64 ATOMIC_ADD
 	#define mb __sync_synchronize
-	#define lmb() asm volatile( "lfence" )
-	#define smb() asm volatile( "sfence" )
+#if  defined(__x86_64__) || defined(__i386)
+//	#define lmb() asm volatile( "lfence" )
+//	#define smb() asm volatile( "sfence" )
+	#define lmb() asm volatile("":::"memory")   // compiler barrier only.  runtime reordering already impossible on x86
+	#define smb() asm volatile("":::"memory")
+#endif // else no definition
 
 	// thread
 	#include <pthread.h>

--- a/lfq.c
+++ b/lfq.c
@@ -84,6 +84,24 @@ int lfq_init(struct lfq_ctx *ctx, int max_consume_thread) {
 	return 0;
 }
 
+
+long lfg_count_freelist(const struct lfq_ctx *ctx) {
+	long count=0;
+	struct lfq_node *p = (struct lfq_node *)ctx->fph; // non-volatile
+	while(p) {
+		count++;
+		p = p->next;
+	}
+/*
+	while(pn = p->free_next) {
+		free(p);
+		p = pn;
+		count++;
+	}
+*/
+	return count;
+}
+
 int lfq_clean(struct lfq_ctx *ctx){
 	if ( ctx->tail && ctx->head ) { // if have data in queue
 		struct lfq_node *tmp;

--- a/lfq.c
+++ b/lfq.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #define MAXFREE 150
 
+static
 int inHP(struct lfq_ctx *ctx, struct lfq_node * lfn) {
 	for ( int i = 0 ; i < ctx->MAXHPSIZE ; i++ ) {
 		lmb();
@@ -20,6 +21,7 @@ void enpool(struct lfq_ctx *ctx, struct lfq_node * lfn) {
 	p->free_next = lfn;
 }
 
+static
 void free_pool(struct lfq_ctx *ctx, bool freeall ) {
 	if (!CAS(&ctx->is_freeing, 0, 1))
 		return; // this pool free is not support multithreading.
@@ -37,6 +39,7 @@ exit:
 	smb();
 }
 
+static
 void safe_free(struct lfq_ctx *ctx, struct lfq_node * lfn) {
 	if (lfn->can_free && !inHP(ctx,lfn)) {
 		 // free is not thread safety
@@ -51,6 +54,7 @@ void safe_free(struct lfq_ctx *ctx, struct lfq_node * lfn) {
 	free_pool(ctx, false);
 }
 
+static
 int alloc_tid(struct lfq_ctx *ctx) {
 	for (int i = 0; i < ctx->MAXHPSIZE; i++) 
 		if (ctx->tid_map[i] == 0) 
@@ -60,6 +64,7 @@ int alloc_tid(struct lfq_ctx *ctx) {
 	return -1;
 }
 
+static
 void free_tid(struct lfq_ctx *ctx, int tid) {
 	ctx->tid_map[tid]=0;
 }

--- a/lfq.c
+++ b/lfq.c
@@ -98,7 +98,7 @@ long lfg_count_freelist(const struct lfq_ctx *ctx) {
 	struct lfq_node *p = (struct lfq_node *)ctx->fph; // non-volatile
 	while(p) {
 		count++;
-		p = p->next;
+		p = p->free_next;
 	}
 /*
 	while(pn = p->free_next) {

--- a/lfq.h
+++ b/lfq.h
@@ -26,6 +26,8 @@ struct lfq_ctx{
 
 int lfq_init(struct lfq_ctx *ctx, int max_consume_thread);
 int lfq_clean(struct lfq_ctx *ctx);
+long lfg_count_freelist(const struct lfq_ctx *ctx);
+
 int lfq_enqueue(struct lfq_ctx *ctx, void * data);
 void * lfq_dequeue_tid(struct lfq_ctx *ctx, int tid );
 void * lfq_dequeue(struct lfq_ctx *ctx );

--- a/lfq.h
+++ b/lfq.h
@@ -2,6 +2,8 @@
 #define __LFQ_H__
 #include "cross-platform.h"
 
+#include <stdalign.h>  // C11
+
 struct lfq_node{
 	void * data;
 	struct lfq_node * volatile next;
@@ -10,8 +12,7 @@ struct lfq_node{
 };
 
 struct lfq_ctx{
-	volatile struct lfq_node  * volatile head;
-	volatile struct lfq_node  * volatile tail;
+	alignas(64)	volatile struct lfq_node  * volatile head;
 	int volatile count;
 	volatile struct lfq_node * * HP;
 	volatile int * tid_map;
@@ -19,6 +20,8 @@ struct lfq_ctx{
 	volatile struct lfq_node * volatile fph; // free pool head
 	volatile struct lfq_node * volatile fpt; // free pool tail
 	int MAXHPSIZE;
+
+	alignas(64) volatile struct lfq_node  * volatile tail;  // in another cache line to avoid contention
 };
 
 int lfq_init(struct lfq_ctx *ctx, int max_consume_thread);

--- a/test_multithread.c
+++ b/test_multithread.c
@@ -131,6 +131,6 @@ int main() {
 		printf("Test PASS!!\n");
 	else
 		printf("Test Failed!!\n");
-	lfq_clean(&ctx);
+
 	return (cn_added != cn_deled);
 }

--- a/test_multithread.c
+++ b/test_multithread.c
@@ -122,8 +122,11 @@ int main() {
 	
 	for ( i = 0 ; i < MAX_CONSUMER ; i++ )
 		THREAD_WAIT(thread_d[i]);
-	
-	printf("Total push %"PRId64" elements, pop %"PRId64" elements.\n", cn_added, cn_deled );
+
+	long freecount = lfg_count_freelist(&ctx);
+	int clean = lfq_clean(&ctx);
+
+	printf("Total push %"PRId64" elements, pop %"PRId64" elements. freelist=%ld, clean = %d\n", cn_added, cn_deled, freecount, clean);
 	if ( cn_added == cn_deled )
 		printf("Test PASS!!\n");
 	else


### PR DESCRIPTION
This doesn't fix everything: there's still a use-after-free bug in here somewhere, even with `mfence` instead of `lfence` or `sfence` in case even stronger barriers made a difference at the locations you had them.

`continue` goes to the end of the loop body, not the top.  So `if(we lose the race) continue;` attempts a CAS with uninitialized (or NULL) `pn`.  That's a bug.

The rest of this is some cleanups and improvements to the Makefile and tests.

By setting `p->next` to `(void*)-1` right before `free()`ing, we can detect use-after free: we'll never see that pointer value normally (because it's not aligned, and other reasons), so if we ever read that from memory we know we *shouldn't* have read that memory, and it could have faulted.

I didn't commit all these changes perfectly the first time, so a couple later ones fix mistakes in earlier ones.  But after the final one, it compiles with minimal warnings, and the tests run, only sometimes hitting the assertion failure.  (Revealing a bug that already existed, but wasn't being detected before.)